### PR TITLE
🧹 Janitor: Refactor flag parsing from init() to main()

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,13 @@
+## 2026-01-27 - Refactor flag parsing from init() to main()
+
+### Issue
+Flag parsing was done in `init()`, which executes automatically on package import. This makes it difficult to test `main` package logic without triggering flag parsing and potential side effects (like program exit on error).
+
+### Root Cause
+Using `init()` for side-effect heavy initialization like flag parsing and network checks (`GetFreePort`).
+
+### Solution
+Moved flag parsing logic to a dedicated `parseFlags()` function and called it explicitly at the beginning of `main()`.
+
+### Pattern
+Avoid side effects in `init()`. Prefer explicit initialization.

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func GetFreePort() (port int, err error) {
 	return
 }
 
-func init() {
+func parseFlags() {
 	flag.IntVar(&localPort, "l", 0, "Raw TCP port to listen")
 	flag.StringVar(&remote, "t", "", "Which TCP socket, that can be a TLS socket, to proxy")
 	flag.Parse()
@@ -67,6 +67,7 @@ func GetListener() (net.Listener, error) {
 }
 
 func main() {
+	parseFlags()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ln, err := GetListener()


### PR DESCRIPTION
## What Changed
Refactored flag parsing logic from the `init()` function into a dedicated `parseFlags()` function, which is now explicitly called at the beginning of `main()`.

## Why This Helps
Moving side effects (parsing flags, networking checks) out of `init()` improves testability and prevents unexpected behavior when importing the package. It aligns with Go best practices.

## Before/After
**Before:** `init()` automatically parsed flags and could exit the program.
**After:** `parseFlags()` is called explicitly in `main()`.

## Verification
- Verified that `go build` works.
- Verified that `./untls -h` still displays help.
- Verified that running without arguments still errors correctly.
- Ran `go vet` and `go fmt`.

---
*PR created automatically by Jules for task [5105113098630983427](https://jules.google.com/task/5105113098630983427) started by @lucasew*