### PR TITLE
🧹 Janitor: Flatten GetFreePort logic

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,13 @@
+## 2026-02-01 - Flatten GetFreePort logic
+
+### Issue
+The `GetFreePort` function in `listener.go` uses nested conditionals and named return parameters with naked returns. This makes the control flow harder to follow and increases cognitive load ("arrow code").
+
+### Root Cause
+The original implementation nested success checks (`err == nil`) instead of handling errors immediately (guard clauses).
+
+### Solution
+Refactor the function to use guard clauses for error handling. This allows for a linear flow, explicit returns, and removal of named return parameters.
+
+### Pattern
+Refactoring nested `if` statements into guard clauses to improve readability.

--- a/listener.go
+++ b/listener.go
@@ -9,16 +9,19 @@ import (
 
 // from: https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
 // GetFreePort asks the kernel for a free open port that is ready to use.
-func GetFreePort() (port int, err error) {
-	var a *net.TCPAddr
-	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
-		var l *net.TCPListener
-		if l, err = net.ListenTCP("tcp", a); err == nil {
-			defer func() { _ = l.Close() }()
-			return l.Addr().(*net.TCPAddr).Port, nil
-		}
+func GetFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
 	}
-	return
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // CreateListener creates a listener based on the environment or arguments.


### PR DESCRIPTION
## What Changed
Refactored `GetFreePort` in `listener.go` to use guard clauses instead of nested conditionals. Removed named return parameters.

## Why This Helps
-   **Reduces Complexity:** Removes "arrow code" (nested `if`s).
-   **Improves Clarity:** Makes the success path linear and easier to read.
-   **Explicit Returns:** Removes potential confusion from naked returns mixed with named return parameters.

## Before vs After

**Before:**
```go
func GetFreePort() (port int, err error) {
	var a *net.TCPAddr
	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
		var l *net.TCPListener
		if l, err = net.ListenTCP("tcp", a); err == nil {
			defer func() { _ = l.Close() }()
			return l.Addr().(*net.TCPAddr).Port, nil
		}
	}
	return
}
```

**After:**
```go
func GetFreePort() (int, error) {
	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
	if err != nil {
		return 0, err
	}

	l, err := net.ListenTCP("tcp", addr)
	if err != nil {
		return 0, err
	}
	defer func() { _ = l.Close() }()

	return l.Addr().(*net.TCPAddr).Port, nil
}
```

## Verification
-   Ran `mise run test`: All tests passed.
-   Ran `mise run lint`: No issues found.


---
*PR created automatically by Jules for task [3782097019069828586](https://jules.google.com/task/3782097019069828586) started by @lucasew*