### PR TITLE
📝 Docs: Standardize and improve code documentation

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -7,8 +7,24 @@ import (
 	"strconv"
 )
 
-// from: https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
-// GetFreePort asks the kernel for a free open port that is ready to use.
+/**
+ * GetFreePort asks the kernel for a free open port that is ready to use.
+ *
+ * Flow:
+ * 1. Resolves a TCP address on localhost with port 0 (random).
+ * 2. Listens on that address to let the kernel assign a port.
+ * 3. Retrieves the assigned port.
+ * 4. Closes the listener immediately.
+ *
+ * Edge Case:
+ * There is a race condition where another process might bind to the returned port
+ * between the time it is released here and when the caller tries to use it.
+ *
+ * Credit: https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
+ *
+ * @returns {int} port - The free port number.
+ * @returns {error} err - Error if unable to resolve or listen.
+ */
 func GetFreePort() (port int, err error) {
 	var a *net.TCPAddr
 	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
@@ -21,9 +37,19 @@ func GetFreePort() (port int, err error) {
 	return
 }
 
-// CreateListener creates a listener based on the environment or arguments.
-// It checks for systemd activation first.
-// Returns the listener, a description of the source (e.g., "systemd" or "127.0.0.1:port"), and error.
+/**
+ * CreateListener initializes a TCP listener, prioritizing systemd socket activation.
+ *
+ * Logic:
+ * - Checks if `LISTEN_PID` matches the current PID. If so, it assumes systemd passed
+ *   the socket via file descriptor 3 (SD_LISTEN_FDS_START).
+ * - If not running under systemd, it falls back to listening on `127.0.0.1:<port>`.
+ *
+ * @param {int} port - The fallback port to listen on if systemd is not detected.
+ * @returns {net.Listener} - The initialized listener.
+ * @returns {string} - A description of the listener source ("systemd" or "127.0.0.1:<port>").
+ * @returns {error} - Error if listener creation fails.
+ */
 func CreateListener(port int) (net.Listener, string, error) {
 	if os.Getenv("LISTEN_PID") == strconv.Itoa(os.Getpid()) {
 		// systemd run

--- a/main.go
+++ b/main.go
@@ -61,12 +61,12 @@ func main() {
 	}
 }
 
-/*
-bufferPool is a sync.Pool used to reuse byte buffers for I/O operations.
-
-Allocating a new buffer for every connection copy operation would create significant
-garbage collection pressure. Using a pool allows us to recycle these 32KB buffers (1<<15).
-*/
+/**
+ * bufferPool is a sync.Pool used to reuse byte buffers for I/O operations.
+ *
+ * Allocating a new buffer for every connection copy operation would create significant
+ * garbage collection pressure. Using a pool allows us to recycle these 32KB buffers (1<<15).
+ */
 var bufferPool = sync.Pool{
 	New: func() interface{} {
 		// TODO maybe different buffer size?
@@ -76,17 +76,17 @@ var bufferPool = sync.Pool{
 	},
 }
 
-/*
-handleConn bridges the connection between the downstream client and the upstream TLS server.
-
-It initiates a bidirectional copy of data:
-1. Downstream -> Upstream (run in a new goroutine).
-2. Upstream -> Downstream (run in the current goroutine).
-
-It uses sync.Once to ensure that connection cleanup (closing both sockets) happens exactly once,
-preventing double-close errors or resource leaks. When either direction finishes (EOF or error),
-both connections are closed.
-*/
+/**
+ * handleConn bridges the connection between the downstream client and the upstream TLS server.
+ *
+ * It initiates a bidirectional copy of data:
+ * 1. Downstream -> Upstream (run in a new goroutine).
+ * 2. Upstream -> Downstream (run in the current goroutine).
+ *
+ * It uses sync.Once to ensure that connection cleanup (closing both sockets) happens exactly once,
+ * preventing double-close errors or resource leaks. When either direction finishes (EOF or error),
+ * both connections are closed.
+ */
 func handleConn(downstream, upstream net.Conn) {
 	var once sync.Once
 	closeConnections := func() {


### PR DESCRIPTION
# Documentation Improvements

Updated documentation in `listener.go` and `main.go` to use JSDoc/TSDoc style block comments (`/** ... */`) as requested.

## Changes
- **`listener.go`**:
    - `GetFreePort`: Added flow description and race condition warning.
    - `CreateListener`: Added logic description for systemd vs manual execution.
- **`main.go`**:
    - `bufferPool`: Converted to `/** ... */` block comment.
    - `handleConn`: Converted to `/** ... */` block comment.

## Verification
- Ran `mise run fmt` (passed).
- Ran `mise run lint` (passed).
- Ran `mise run test` (passed).

---
*PR created automatically by Jules for task [17391610931929618322](https://jules.google.com/task/17391610931929618322) started by @lucasew*