### PR TITLE
🧹 Janitor: Prevent server crash on upstream connection failure

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-02-08: Server should continue running on per-connection errors instead of exiting.

--- a/main.go
+++ b/main.go
@@ -54,7 +54,8 @@ func main() {
 			upstream, err := tls.Dial("tcp", remote, &tls.Config{})
 			if err != nil {
 				log.Printf("conn/%s: %s", downstream.RemoteAddr(), err)
-				return
+				_ = downstream.Close()
+				continue
 			}
 			go handleConn(downstream, upstream)
 		}


### PR DESCRIPTION
## What Changed
Modified `main.go` to handle `tls.Dial` errors inside the main connection loop. Instead of `return` (which exits the server), it now logs the error, closes the `downstream` connection, and continues to the next iteration.

## Why This Helps
Previously, a single failed connection to the upstream server (e.g., due to temporary network issues or refused connection) would cause the entire `untls` server to crash and exit. This change ensures the server remains resilient and continues to accept new connections even if one upstream connection fails. This significantly reduces chaos and improves maintainability in production environments.

## Before/After
**Before:**
```go
			upstream, err := tls.Dial("tcp", remote, &tls.Config{})
			if err != nil {
				log.Printf("conn/%s: %s", downstream.RemoteAddr(), err)
				return // Crashes server
			}
```

**After:**
```go
			upstream, err := tls.Dial("tcp", remote, &tls.Config{})
			if err != nil {
				log.Printf("conn/%s: %s", downstream.RemoteAddr(), err)
				_ = downstream.Close() // Clean up
				continue // Keep running
			}
```

## Verification
-   **Manual:** Verified that the server no longer crashes when the upstream target is unreachable. Started the server with an invalid upstream address, connected to it, and confirmed it logged the error and remained running for subsequent connections.
-   **Automated:** Ran `mise run ci` (lint and tests) and confirmed all checks pass.

---
*PR created automatically by Jules for task [7395167297139054138](https://jules.google.com/task/7395167297139054138) started by @lucasew*