### PR TITLE
🔇 Denoiser: Add initial patterns to ignore list

### DIFF
--- a/.jules/CONSISTENTLY_IGNORED.md
+++ b/.jules/CONSISTENTLY_IGNORED.md
@@ -1,0 +1,17 @@
+## IGNORE: Refactor GetFreePort
+
+**- Pattern:** Flattening logic or removing named return parameters in `GetFreePort`.
+**- Justification:** The function is a direct copy from a Gist. Refactoring it obscures the origin and makes validation against the source harder.
+**- Files Affected:** `listener.go`
+
+## IGNORE: Enforce TLS Version
+
+**- Pattern:** Setting `MinVersion` in `tls.Config`.
+**- Justification:** As a generic proxy client, the tool must support whatever the upstream server supports. Enforcing TLS 1.2 breaks compatibility with legacy upstreams.
+**- Files Affected:** `main.go`
+
+## IGNORE: Custom Timeout Wrappers
+
+**- Pattern:** Implementing `net.Conn` wrappers (like `idleTimeoutConn`) to handle timeouts.
+**- Justification:** Custom connection wrappers add significant boilerplate complexity and risk introducing bugs. The project prefers simplicity over complex timeout handling unless critical.
+**- Files Affected:** `main.go`


### PR DESCRIPTION
Analyzed recent closed/rejected PRs and synthesized rules for `.jules/CONSISTENTLY_IGNORED.md`.

Added rules for:
- Refactoring `GetFreePort` (matches upstream Gist).
- Enforcing TLS Version (breaks legacy support).
- Custom Timeout Wrappers (adds complexity).

This helps agents avoid proposing changes that are known to be rejected.

---
*PR created automatically by Jules for task [10824768462852330377](https://jules.google.com/task/10824768462852330377) started by @lucasew*