### PR TITLE
🔇 Denoiser: Add rules for server loop exit and flag definitions

### DIFF
--- a/.jules/CONSISTENTLY_IGNORED.md
+++ b/.jules/CONSISTENTLY_IGNORED.md
@@ -15,3 +15,15 @@
 **- Pattern:** Implementing `net.Conn` wrappers (like `idleTimeoutConn`) to handle timeouts.
 **- Justification:** Custom connection wrappers add significant boilerplate complexity and risk introducing bugs. The project prefers simplicity over complex timeout handling unless critical.
 **- Files Affected:** `main.go`
+
+## IGNORE: Change Server Loop Exit Behavior
+
+**- Pattern:** Changing `return` to `continue` (or other recovery logic) when `tls.Dial` fails in the main loop.
+**- Justification:** The current behavior (exit on upstream failure) is intentional; changing it to keep the server running is consistently rejected.
+**- Files Affected:** `main.go`
+
+## IGNORE: Move Flag Definitions
+
+**- Pattern:** Moving `flag` definitions (e.g. `flag.IntVar`) out of `init()`.
+**- Justification:** Flag definitions belong in `init()`; only `flag.Parse()` should be in `main()`.
+**- Files Affected:** `main.go`


### PR DESCRIPTION
**Pattern:** Added new rejection rules based on closed PRs #343 and #345.
**Justification:**
- Server loop must exit on upstream failure (based on rejection of PR #343).
- Flag definitions must remain in `init()` (based on rejection of PR #345).

**Files Affected:** `.jules/CONSISTENTLY_IGNORED.md`

---
*PR created automatically by Jules for task [12113762920069569386](https://jules.google.com/task/12113762920069569386) started by @lucasew*